### PR TITLE
feat: providing logs of container

### DIFF
--- a/client/app/api/container/[id]/logs/route.ts
+++ b/client/app/api/container/[id]/logs/route.ts
@@ -1,0 +1,66 @@
+import Dockerode from "dockerode";
+import Docker from "dockerode";
+import stream from "stream";
+
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const id = params.id;
+
+  const docker = new Docker();
+
+  let allLogs: any = "";
+
+  async function containerLogs(container: Dockerode.Container) {
+    return new Promise((resolve, reject) => {
+      const logStream = new stream.PassThrough();
+
+      logStream.on("data", function (chunk) {
+        allLogs += chunk.toString("utf8");
+        // console.log(allLogs);
+      });
+
+      container.logs(
+        {
+          follow: true,
+          stdout: true,
+          stderr: true,
+        },
+        function (err, stream) {
+          if (err) {
+            reject(err);
+            return;
+          }
+
+          if (!stream) {
+            return;
+          }
+
+          container.modem.demuxStream(stream, logStream, logStream);
+
+          stream.on("end", function () {
+            logStream.end("!stop!");
+          });
+
+          setTimeout(function () {
+            // stream.destroy();
+            resolve({});
+          }, 1200);
+        }
+      );
+    });
+  }
+
+  try {
+    const container = docker.getContainer(id);
+
+    await containerLogs(container);
+
+    return new Response(allLogs);
+  } catch (error) {
+    return new Response(JSON.stringify({ error: error }), {
+      status: 500,
+    });
+  }
+}

--- a/client/components/listLogs.tsx
+++ b/client/components/listLogs.tsx
@@ -1,0 +1,76 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import Dockerode from "dockerode";
+import React, { useEffect, useState } from "react";
+import { ScrollArea } from "./ui/scroll-area";
+import {
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "./ui/dialog";
+import { Button } from "./ui/button";
+
+const ListLogs = ({ space }: { space: Dockerode.ContainerInfo }) => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [logs, setLogs] = useState("");
+
+  const fetchLogs = async () => {
+    setIsLoading(true);
+    try {
+      const response = await fetch(`/api/container/${space.Id}/logs`);
+      const text = await response.text();
+      setLogs(text);
+    } catch (error) {
+      console.log(error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchLogs();
+  }, []);
+
+  return (
+    <DialogContent className="sm:max-w-[1000px] h-[80vh] mx-10 ">
+      <DialogHeader>
+        <DialogTitle>Logs</DialogTitle>
+        <DialogDescription className="flex justify-between items-center w-full">
+          <p>
+            Logs of the container {space.Names[0].replace("/", "")} -
+            {space.Id.slice(0, 12)}.
+          </p>
+          <Button disabled={isLoading} onClick={fetchLogs}>
+            {isLoading ? "refresh..." : "refresh"}
+          </Button>
+        </DialogDescription>
+      </DialogHeader>
+      <div className="flex items-center space-x-2">
+        <div className=" w-full">
+          {isLoading ? (
+            <div className="h-[400px] w-[900px] p-4 flex items-center justify-center">
+                Loading...
+            </div>
+          ) : (
+            <div className="w-full flex items-center justify-center">
+              <ScrollArea className="h-[400px] w-[900px] rounded-md border p-4">
+                <pre>{logs}</pre>
+              </ScrollArea>
+            </div>
+          )}
+        </div>
+      </div>
+      <DialogFooter className="sm:justify-start">
+        <DialogClose asChild>
+          <Button type="button" variant="secondary">
+            Close
+          </Button>
+        </DialogClose>
+      </DialogFooter>
+    </DialogContent>
+  );
+};
+
+export default ListLogs;

--- a/client/components/listSpaces.tsx
+++ b/client/components/listSpaces.tsx
@@ -19,6 +19,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import Link from "next/link";
+import ListLogs from "./listLogs";
 
 const ListSpaces = ({
   space,
@@ -69,9 +70,10 @@ const ListSpaces = ({
     <Card className="w-full p-4 flex justify-between items-center rounded-none border-r-0 border-l-0 border-b-0 border-t">
       <div>
         <div className="flex items-center">
-          <p className="text-lg font-semibold">
-            {space.Names[0].replace("/", "")} {" - "}
+          <p className="text-lg font-semibold mr-2">
+            {space.Names[0].replace("/", "")}
           </p>
+          {" - "}
           <p className="text-muted-foreground text-xs mx-2">
             {space.Id.slice(0, 12)}
           </p>
@@ -155,6 +157,13 @@ const ListSpaces = ({
             ? "Start..."
             : "Start"}
         </Button>
+
+        <Dialog>
+          <DialogTrigger asChild>
+            <Button variant="outline">Logs</Button>
+          </DialogTrigger>
+          <ListLogs space={space} />
+        </Dialog>
         {space.State === "running" ? (
           <Button asChild>
             <Link

--- a/client/components/ui/scroll-area.tsx
+++ b/client/components/ui/scroll-area.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import * as React from "react"
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
+
+import { cn } from "@/lib/utils"
+
+const ScrollArea = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
+>(({ className, children, ...props }, ref) => (
+  <ScrollAreaPrimitive.Root
+    ref={ref}
+    className={cn("relative overflow-hidden", className)}
+    {...props}
+  >
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+      {children}
+    </ScrollAreaPrimitive.Viewport>
+    <ScrollBar />
+    <ScrollAreaPrimitive.Corner />
+  </ScrollAreaPrimitive.Root>
+))
+ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName
+
+const ScrollBar = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
+>(({ className, orientation = "vertical", ...props }, ref) => (
+  <ScrollAreaPrimitive.ScrollAreaScrollbar
+    ref={ref}
+    orientation={orientation}
+    className={cn(
+      "flex touch-none select-none transition-colors",
+      orientation === "vertical" &&
+        "h-full w-2.5 border-l border-l-transparent p-[1px]",
+      orientation === "horizontal" &&
+        "h-2.5 flex-col border-t border-t-transparent p-[1px]",
+      className
+    )}
+    {...props}
+  >
+    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
+  </ScrollAreaPrimitive.ScrollAreaScrollbar>
+))
+ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName
+
+export { ScrollArea, ScrollBar }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-dropdown-menu": "^2.0.6",
         "@radix-ui/react-icons": "^1.3.0",
         "@radix-ui/react-label": "^2.0.2",
+        "@radix-ui/react-scroll-area": "^1.0.5",
         "@radix-ui/react-slot": "^1.0.2",
         "@radix-ui/react-tooltip": "^1.0.7",
         "class-variance-authority": "^0.7.0",
@@ -473,6 +474,14 @@
         "node": ">=14"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.0.1.tgz",
+      "integrity": "sha512-T5gIdVO2mmPW3NNhjNgEP3cqMXjXL9UbO0BzWcXfvdBs+BohbQxvd/K5hSVKmn9/lbTdsQVKbUcP5WLCwvUbBg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.1.tgz",
@@ -921,6 +930,37 @@
         "@radix-ui/react-primitive": "1.0.3",
         "@radix-ui/react-use-callback-ref": "1.0.1",
         "@radix-ui/react-use-controllable-state": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.0.5.tgz",
+      "integrity": "sha512-b6PAgH4GQf9QEn8zbT2XUHpW5z8BzqEc7Kl11TwDrvuTrxlkcjTD5qa/bxgKr+nmuXKu4L/W5UZ4mlP/VG/5Gw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/number": "1.0.1",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/client/package.json
+++ b/client/package.json
@@ -13,6 +13,7 @@
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-label": "^2.0.2",
+    "@radix-ui/react-scroll-area": "^1.0.5",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-tooltip": "^1.0.7",
     "class-variance-authority": "^0.7.0",


### PR DESCRIPTION

![image](https://github.com/ruru-m07/assignment-cloud-IDE-v1/assets/142723369/45b6d629-45c3-487a-a7e3-feedb20df087)


### build checks passed

```bash
$ npm run build

> client@0.1.0 build
> next build

  ▲ Next.js 14.2.3

   Creating an optimized production build ...
 ✓ Compiled successfully
 ✓ Linting and checking validity of types    
 ✓ Collecting page data    
 ✓ Generating static pages (9/9)
 ✓ Collecting build traces    
 ✓ Finalizing page optimization

Route (app)                              Size     First Load JS
┌ ○ /                                    22 kB           130 kB
├ ○ /_not-found                          871 B          87.9 kB
├ ○ /api                                 0 B                0 B
├ ƒ /api/container/[id]                  0 B                0 B
├ ƒ /api/container/[id]/logs             0 B                0 B
├ ƒ /api/getpassword                     0 B                0 B
├ ○ /api/listcontainers                  0 B                0 B
└ ƒ /api/new                             0 B                0 B
+ First Load JS shared by all            87 kB
  ├ chunks/23-91b6d8f3c184767f.js        31.5 kB
  ├ chunks/fd9d1056-82fc2a82826c61b9.js  53.6 kB
  └ other shared chunks (total)          1.9 kB


○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand
```